### PR TITLE
Add setAppOpsUidMode

### DIFF
--- a/client/src/main/java/com/catchingnow/delegatedscopeclient/DSMClient.java
+++ b/client/src/main/java/com/catchingnow/delegatedscopeclient/DSMClient.java
@@ -118,6 +118,8 @@ public class DSMClient {
      *
      *     adb shell pm grant com.your.package android.permission.GET_APP_OPS_STATS
      *
+     * In the behind, setMode is called.
+     *
      * @param context context
      * @param opCode code
      * @param uid uid
@@ -127,6 +129,28 @@ public class DSMClient {
     @RequiresApi(api = Build.VERSION_CODES.P)
     public static void setAppOpsMode(Context context, int opCode, int uid, String packageName, int mode) throws Exception {
         DSMClinetImplement.setAppOpsMode(context, opCode, uid, packageName, mode);
+    }
+
+    /**
+     *
+     * Set the AppOps state.
+     *
+     * The device owner can only SET the AppOps states but can not GET the AppOps states.
+     * For get the AppOps state you have to register the "android.permission.GET_APP_OPS_STATS" permission in manifests.
+     * Then ask user to grant it manually through ADB command:
+     *
+     *     adb shell pm grant com.your.package android.permission.GET_APP_OPS_STATS
+     *
+     * In the behind, setUidMode is called.
+     *
+     * @param context context
+     * @param opCode code
+     * @param uid uid
+     * @param mode mode
+     */
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    public static void setAppOpsUidMode(Context context, int opCode, int uid, int mode) throws Exception {
+        DSMClinetImplement.setAppOpsUidMode(context, opCode, uid, mode);
     }
 
     /**

--- a/client/src/main/java/com/catchingnow/delegatedscopeclient/DSMClinetImplement.java
+++ b/client/src/main/java/com/catchingnow/delegatedscopeclient/DSMClinetImplement.java
@@ -152,6 +152,20 @@ class DSMClinetImplement extends DSMClient {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.P)
+    public static void setAppOpsUidMode(Context context, int opCode, int uid, int mode) throws Exception {
+        Bundle bundle = new Bundle();
+        bundle.putInt(EXTRA_APP_OP_CODE, opCode);
+        bundle.putInt(Intent.EXTRA_UID, uid);
+        bundle.putInt(EXTRA_APP_OP_MODE, mode);
+        Bundle call = context.getContentResolver().call(Uri.parse("content://" + getOwnerPackageNameInternal(context) +
+                        ".DSM_CENTER"),
+                METHOD_SET_APP_OPS, null, bundle);
+        if (call != null && call.containsKey(Intent.ACTION_APP_ERROR)) {
+            throw (Exception) call.getSerializable(Intent.ACTION_APP_ERROR);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
     public static void resetAppOps(Context context, int userId, String packageName) throws Exception {
         Bundle bundle = new Bundle();
         bundle.putInt(EXTRA_USER_ID, userId);

--- a/manager/src/main/java/com/catchingnow/delegatedscopesmanager/centerApp/CenterAppBridge.java
+++ b/manager/src/main/java/com/catchingnow/delegatedscopesmanager/centerApp/CenterAppBridge.java
@@ -103,11 +103,19 @@ public class CenterAppBridge {
 
     @SuppressLint("NewApi")
     private static Bundle setAppOps(Context context, Bundle extras) {
-        AppOpsUtil.setMode(context,
-                extras.getInt(EXTRA_APP_OP_CODE),
-                extras.getInt(Intent.EXTRA_UID),
-                extras.getString(Intent.EXTRA_PACKAGE_NAME),
-                extras.getInt(EXTRA_APP_OP_MODE));
+        if (extras.containsKey(Intent.EXTRA_PACKAGE_NAME)) {
+            AppOpsUtil.setMode(context,
+                    extras.getInt(EXTRA_APP_OP_CODE),
+                    extras.getInt(Intent.EXTRA_UID),
+                    extras.getString(Intent.EXTRA_PACKAGE_NAME),
+                    extras.getInt(EXTRA_APP_OP_MODE));
+        } else {
+            AppOpsUtil.setUidMode(context,
+                    extras.getInt(EXTRA_APP_OP_CODE),
+                    extras.getInt(Intent.EXTRA_UID),
+                    extras.getInt(EXTRA_APP_OP_MODE));
+        }
+
         return new Bundle();
     }
 

--- a/manager/src/main/java/com/catchingnow/delegatedscopesmanager/customAbilty/AppOpsUtil.java
+++ b/manager/src/main/java/com/catchingnow/delegatedscopesmanager/customAbilty/AppOpsUtil.java
@@ -30,6 +30,19 @@ public class AppOpsUtil {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.P)
+    public static void setUidMode(Context context, int opCode, int uid, int mode) {
+        if (sManager == null) {
+            sManager = context.getSystemService(AppOpsManager.class);
+        }
+        Hack.into(AppOpsManager.class)
+                .method("setUidMode")
+                .returning(void.class)
+                .withParams(int.class, int.class, int.class)
+                .invoke(opCode, uid, mode)
+                .on(sManager);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.P)
     public static void resetAllModes(int userId, String packageName) throws RemoteException {
         IBinder binder = Hack.into("android.os.ServiceManager")
                 .staticMethod("getService")


### PR DESCRIPTION
On Android P or even earlier, uid mode rather than package mode is used for runtime permissions. To modify uid mode, setUidMode should be used.

This commit adds setAppOpsUidMode in the client which does not set EXTRA_PACKAGE_NAME, so the manager can use this to judge is setUidMode should be used.